### PR TITLE
Added Finite State Machine and variable jump force

### DIFF
--- a/Assets/code_src/PlayerController.cs
+++ b/Assets/code_src/PlayerController.cs
@@ -5,31 +5,28 @@ using System;
 
 public class PlayerController : MonoBehaviour
 {
-    public float MAX_FIRST_JUMP_TIME = 1f;
-    public float MELEE_WEAPON_ACTIVE_TIME = 0.1f;
-    public const int MAX_JUMP_COUNT = 2;
-    public const float INPUT_DEAD_ZONE = 0.1f;
-
     public float maxXSpeed;
     public float maxYSpeed;
-
     private float inputX;
     private bool meleeKeyJustPressed;
     private bool jumpKeyJustPressed;
     private bool jumpKeyHeldDown;
-
     public float firstJumpTimer;
     public float firstJumpForce;
     public float firstJumpInProgressForce;
     public float doubleJumpForce;
-
     private Rigidbody2D rb;
-
     private int currentJumpCount;
-
     private bool isGrounded;
     private MeleeWeapon meleeWeapon;
     private TimedActionManager timedActionManager;
+    private VerticalMovementState verticalMovementState;
+    private HorizontalMovementState horizontalMovementState;
+    private const float MAX_FIRST_JUMP_TIME = 1f;
+    private const float MELEE_WEAPON_ACTIVE_TIME = 0.1f;
+    private const int MAX_JUMP_COUNT = 2;
+    private const float INPUT_DEAD_ZONE = 0.1f;
+
     private enum VerticalMovementState
     {
         Error,
@@ -49,9 +46,6 @@ public class PlayerController : MonoBehaviour
         RunningLeft,
         RunningRight
     }
-
-    private VerticalMovementState verticalMovementState;
-    private HorizontalMovementState horizontalMovementState;
 
     private const string MELEE_WEAPON_ACTIVE_TIME_KEY = "MELEE_WEAPON_ACTIVE_TIME_KEY";
 

--- a/Assets/code_src/PlayerController.cs
+++ b/Assets/code_src/PlayerController.cs
@@ -29,13 +29,27 @@ public class PlayerController : MonoBehaviour
 
     private enum VerticalMovementState
     {
+        // Default state if no state can be determined.
         Error,
+
         Standing,
+
+        // First fixed update tick when a jump is started.
         FirstJumpStart,
+
+        // When jump key is being held down and upward force is being applied to player
         FirstJumpInProgress,
+
+        // When either the jump key is released or the max first jump timer gets exceeded.
+        // The player's velocity will slowly decrease until they go into the falling state when their vertical velocity is negative.
         FirstJumpCompleted,
+
+        // First fixed update tick when a double jump is started.
         DoubleJumpStart,
+
+        // State after a player does a double jump and their vertical velocity is still positive.
         DoubleJumpCompleted,
+
         Falling
     }
 

--- a/Assets/code_src/PlayerController.cs
+++ b/Assets/code_src/PlayerController.cs
@@ -56,9 +56,9 @@ public class PlayerController : MonoBehaviour
     private enum HorizontalMovementState
     {
         Error,
-        Standing,
-        RunningLeft,
-        RunningRight
+        NotMoving,
+        MovingLeft,
+        MovingRight
     }
 
     private const string MELEE_WEAPON_ACTIVE_TIME_KEY = "MELEE_WEAPON_ACTIVE_TIME_KEY";
@@ -97,15 +97,15 @@ public class PlayerController : MonoBehaviour
 
         if (inputX > INPUT_DEAD_ZONE)
         {
-            newState = HorizontalMovementState.RunningRight;
+            newState = HorizontalMovementState.MovingRight;
         }
         else if (inputX < -INPUT_DEAD_ZONE)
         {
-            newState = HorizontalMovementState.RunningLeft;
+            newState = HorizontalMovementState.MovingLeft;
         }
         else
         {
-            newState = HorizontalMovementState.Standing;
+            newState = HorizontalMovementState.NotMoving;
         }
 
         return newState;
@@ -215,10 +215,10 @@ public class PlayerController : MonoBehaviour
     {
         switch (horizontalMovementState)
         {
-            case HorizontalMovementState.Standing:
+            case HorizontalMovementState.NotMoving:
                 break;
-            case HorizontalMovementState.RunningRight:
-            case HorizontalMovementState.RunningLeft:
+            case HorizontalMovementState.MovingRight:
+            case HorizontalMovementState.MovingLeft:
                 rb.AddForce(new Vector2(inputX * maxXSpeed, 0f), ForceMode2D.Impulse);
                 break;
 

--- a/Assets/code_src/PlayerController.cs
+++ b/Assets/code_src/PlayerController.cs
@@ -244,7 +244,6 @@ public class PlayerController : MonoBehaviour
                 rb.AddForce(new Vector2(0f, firstJumpInProgressForce), ForceMode2D.Force);
                 break;
             case VerticalMovementState.FirstJumpCompleted:
-                jumpKeyHeldDown = false;
                 break;
 
             case VerticalMovementState.DoubleJumpStart:
@@ -254,7 +253,6 @@ public class PlayerController : MonoBehaviour
                 break;
 
             case VerticalMovementState.DoubleJumpCompleted:
-                jumpKeyHeldDown = false;
                 break;
 
             case VerticalMovementState.Falling:

--- a/Assets/code_src/PlayerController.cs
+++ b/Assets/code_src/PlayerController.cs
@@ -187,9 +187,9 @@ public class PlayerController : MonoBehaviour
 
         jumpKeyHeldDown = Input.GetKey(KeyCode.Space);
 
-        if (!meleeKeyJustPressed)
+        if (Input.GetKeyDown(KeyCode.E))
         {
-            meleeKeyJustPressed = Input.GetKeyDown(KeyCode.E);
+            meleeKeyJustPressed = true;
         }
 
         inputX = Input.GetAxisRaw("Horizontal");
@@ -203,7 +203,7 @@ public class PlayerController : MonoBehaviour
         horizontalMovementState = GetHorizontalMovementState();
     }
 
-    private void MovePlayer()
+    private void MovePlayerHorizontally()
     {
         switch (horizontalMovementState)
         {
@@ -215,7 +215,10 @@ public class PlayerController : MonoBehaviour
                 break;
 
         }
+    }
 
+    private void MovePlayerVertically()
+    {
         switch (verticalMovementState)
         {
             case VerticalMovementState.Standing:
@@ -229,7 +232,7 @@ public class PlayerController : MonoBehaviour
                 rb.AddForce(new Vector2(0f, firstJumpForce), ForceMode2D.Impulse);
                 break;
             case VerticalMovementState.FirstJumpInProgress:
-                firstJumpTimer += Time.deltaTime;
+                IncrementFirstJumpTimer();
                 rb.AddForce(new Vector2(0f, firstJumpInProgressForce), ForceMode2D.Force);
                 break;
             case VerticalMovementState.FirstJumpCompleted:
@@ -252,16 +255,36 @@ public class PlayerController : MonoBehaviour
             case VerticalMovementState.Error:
                 break;
         }
+    }
 
+    private void LimitVelocityIfTooMuch()
+    {
         float currentXSpeed = rb.velocity.x;
         float currentYSpeed = rb.velocity.y;
 
         Vector2 clampedVelocity = rb.velocity;
 
         clampedVelocity.x = Mathf.Clamp(currentXSpeed, -maxXSpeed, maxXSpeed);
-        //clampedVelocity.y = Mathf.Clamp(currentYSpeed, -maxYSpeed, maxYSpeed);
+        clampedVelocity.y = Mathf.Clamp(currentYSpeed, -maxYSpeed, maxYSpeed);
 
         rb.velocity = clampedVelocity;
+    }
+
+    private void HandlePlayerAttacks()
+    {
+        if (meleeKeyJustPressed)
+        {
+            meleeKeyJustPressed = false;
+            MeleeAttack();
+        }
+    }
+
+    private void MovePlayer()
+    {
+        MovePlayerHorizontally();
+        MovePlayerVertically();
+        LimitVelocityIfTooMuch();
+        HandlePlayerAttacks();
     }
 
     private void FixedUpdate()

--- a/Assets/scenes/island_topia.unity
+++ b/Assets/scenes/island_topia.unity
@@ -1333,10 +1333,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 35d5561618f22ef49b373887f68e8852, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  MAX_FIRST_JUMP_TIME: 0.2
   MELEE_WEAPON_ACTIVE_TIME: 0.1
-  maxXSpeed: 4
+  maxXSpeed: 5
   maxYSpeed: 8
-  jumpForce: 8
+  firstJumpTimer: 0
+  firstJumpForce: 6
+  firstJumpInProgressForce: 10
+  doubleJumpForce: 6
 --- !u!50 &787844049
 Rigidbody2D:
   serializedVersion: 4


### PR DESCRIPTION
I added a finite state machine design for our player. Using a finite state machine will make it a lot easier to implement physics and custom animations for player states. The player has two finite state machines, one for vertical movement and one for horizontal movement. The player also has a variable first jump height; the longer they hold the jump button, the longer the first jump will be (up to a limit though, which is determined by a constant).

### Vertical Movement State

```
    private enum VerticalMovementState
    {
        // Default state if no state can be determined.
        Error,

        Standing,

        // First fixed update tick when a jump is started.
        FirstJumpStart,

        // When jump key is being held down and upward force is being applied to player
        FirstJumpInProgress,

        // When either the jump key is released or the max first jump timer gets exceeded.
        // The player's velocity will slowly decrease until they go into the falling state when their vertical velocity is negative.
        FirstJumpCompleted,

        // First fixed update tick when a double jump is started.
        DoubleJumpStart,

        // State after a player does a double jump and their vertical velocity is still positive.
        DoubleJumpCompleted,

        Falling
    }
```

### Horizontal Movement State
```
    private enum HorizontalMovementState
    {
        Error,
        Standing,
        RunningLeft,
        RunningRight
    }
```